### PR TITLE
Update platform version to 1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,65 @@ You can follow the steps [here](http://docs.aws.amazon.com/elasticbeanstalk/late
 
 Be aware that the build process will leave a beanstalk environment running which is used to run Packer. You will have to kill this environment manually when the process is done.
 
+### Build proccess samples (recommended)
+
+```sh
+$ export AWS_EB_PROFILE=orca
+$ export AWS_EB_REGION=ap-northeast-1
+$ ebp init
+
+Select a default region
+1) us-east-1 : US East (N. Virginia)
+2) us-west-1 : US West (N. California)
+3) us-west-2 : US West (Oregon)
+4) eu-west-1 : EU (Ireland)
+5) eu-central-1 : EU (Frankfurt)
+6) ap-south-1 : Asia Pacific (Mumbai)
+7) ap-southeast-1 : Asia Pacific (Singapore)
+8) ap-southeast-2 : Asia Pacific (Sydney)
+9) ap-northeast-1 : Asia Pacific (Tokyo)
+10) ap-northeast-2 : Asia Pacific (Seoul)
+11) sa-east-1 : South America (Sao Paulo)
+12) cn-north-1 : China (Beijing)
+13) cn-northwest-1 : China (Ningxia)
+14) us-east-2 : US East (Ohio)
+15) ca-central-1 : Canada (Central)
+16) eu-west-2 : EU (London)
+17) eu-west-3 : EU (Paris)
+18) eu-north-1 : EU (Stockholm)
+19) eu-south-1 : EU (Milano)
+20) ap-east-1 : Asia Pacific (Hong Kong)
+21) me-south-1 : Middle East (Bahrain)
+22) af-south-1 : Africa (Cape Town)
+(default is 3): 9
+
+
+Select a platform to use
+1) ubuntu-docker-platform
+2) [ Create new Platform ]
+(default is 1): 1
+
+Would you like to be able to log into your platform packer environment?
+(Y/n): Y
+
+Select a keypair.
+1) akihiro.miyashita
+2) aws-eb
+3) orca-codeprep-prod
+4) orca-dev
+5) orca-track-prod
+6) orca-track-staging
+7) [ Create new KeyPair ]
+(default is 6): 4
+
+$ # specify and execute new version.
+$ ebp create 1.x.x
+```
+
+### How to test of build artifacts
+
+An AMI will be created with the name `64bit Ubuntu xx.xx x.x.x running Docker`, and you can use it to create an EC2 instance and connect to it via SSH to check the environment. 
+
 ## Zero Downtime Deploys
 
 This platform takes advantage of the `SO_REUSEPORT` socket option. The general strategy is as follows:

--- a/builder/setup-scripts/02-install-docker.sh
+++ b/builder/setup-scripts/02-install-docker.sh
@@ -16,7 +16,7 @@ add-apt-repository -y \
    stable"
 
 apt-get update -y
-apt-get install -y docker-ce=17.06.2~ce-0~ubuntu
+apt-get install -y docker-ce=5:20.10.7~3-0~ubuntu-xenial
 
 # Add user ubuntu to the docker group
 gpasswd -a ubuntu docker

--- a/custom_platform.json
+++ b/custom_platform.json
@@ -9,7 +9,7 @@
       "type": "amazon-ebs",
       "name": "HVM AMI builder",
       "region": "ap-northeast-1",
-      "source_ami": "ami-ea4eae8c",
+      "source_ami": "ami-0e42827f7b2eaa246",
       "instance_type": "t2.micro",
       "ssh_username": "ubuntu",
       "ssh_pty": "true",

--- a/platform.yaml
+++ b/platform.yaml
@@ -19,4 +19,4 @@ metadata:
   operating_system_name: Ubuntu
   operating_system_version: 16.04
   programming_language_name: Go
-  programming_language_version: 1.9
+  programming_language_version: 1.17

--- a/platform.yaml
+++ b/platform.yaml
@@ -6,7 +6,7 @@
 #
 #   or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-version: "1.2.0"
+version: "1.0"
 
 provisioner:
   type: packer

--- a/platform.yaml
+++ b/platform.yaml
@@ -19,4 +19,4 @@ metadata:
   operating_system_name: Ubuntu
   operating_system_version: 16.04
   programming_language_name: Go
-  programming_language_version: 1.17
+  programming_language_version: 1.16.3

--- a/platform.yaml
+++ b/platform.yaml
@@ -6,7 +6,7 @@
 #
 #   or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-version: "1.0.0"
+version: "1.2.0"
 
 provisioner:
   type: packer


### PR DESCRIPTION
### 対応内容
- docker を 20.10.7 に変更
- go を 0.16.3 に変更 ([ここ](https://github.com/givery-technology/orca/blob/master/.circleci/BuildDockerfile#L1)に合わせる)
- ami を 20210721 時点のものに変更
- README に手順を加筆

resolves: https://github.com/givery-technology/givery-infrastructures/issues/103
